### PR TITLE
Added very faint shadow behind the window to help is stand out a bit from the background

### DIFF
--- a/app/src/style.css
+++ b/app/src/style.css
@@ -56,20 +56,19 @@ body {
     font-family: 'Product Sans';
     -webkit-user-select: none;
     background: transparent;
-
     transition: color 150ms ease-in;
 }
 
 #master-bg {
     z-index: -10;
     position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    right: 0;
+    top: 2px;
+    left: 3px;
+    bottom: 7px;
+    right: 3px;
     background: var(--color-bg);
     border-radius: var(--window-border-radius);
-
+    box-shadow: 0 3px 5px 0 rgba(0, 0, 0, 0.2);
     transition: all 150ms ease-in;
 }
 
@@ -596,8 +595,9 @@ body {
 #assistant-persistent-bar {
     z-index: 0;
     position: absolute;
-    bottom: 0;
-    left: 0;
+    bottom: 7px;
+    left: 3px;
+    right: 3px;
     width: 100%;
     display: block;
     border-bottom-left-radius: var(--window-border-radius);


### PR DESCRIPTION
When using GA on top of a window with the same or similar background color it's sometimes quite hard to differentiate between GA and the window behind it.
I've added a faint shadow which should help it stand out a bit