### PR TITLE
Open the main window when opening a second instance

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,7 +98,23 @@ let openedAtLogin = (process.platform === 'darwin')
                         : argv.includes('--sys-startup');
 
 if (!gotInstanceLock) {
-    debugLog('Another instance is already running', 'warn');
+    // Prevent opening of first instance when launched in Dev Mode
+    // Makes sure the developer is launching a fresh instance for testing
+    if (isDevMode()) {
+        debugLog('Another instance is already running', 'warn');
+
+        electron.dialog.showErrorBox(
+            "Preventing launch", [
+                "An instance of Google Assistant is already running.",
+                "Operation Aborted\n",
+                "You are prompted with this error since you are launching the app in Dev Mode.",
+            ].join('\n')
+        );
+    }
+    else {
+        debugLog('Another instance is already running. Switching to first instance...');
+    }
+
     app.isQuiting = true;
     app.quit();
 }
@@ -109,7 +125,15 @@ else {
     app.commandLine.appendSwitch('enable-transparent-visuals');
     app.commandLine.appendSwitch('disable-features', 'HardwareMediaKeyHandling');
 
-    app.on('second-instance', launchAssistant);
+    app.on('second-instance', (_, args) => {
+        // Switch to current instance if a non dev-mode
+        // instance is launched.
+        if (!isDevMode(args[0])) {
+            if (!mainWindow.isVisible()) launchAssistant();
+            else mainWindow.focus();
+        }
+    });
+
     app.on('ready', () => setTimeout(onAppReady, 800));
 }
 
@@ -468,9 +492,13 @@ function _isLinux() {
 
 /**
  * Checks if the application is running in Development mode.
+ * 
+ * @param {string?} execPath
+ * Path of the executable. Typically `argv[0]`.
+ * If left blank, current executable path will be used.
  */
-function isDevMode() {
-    let executablePath = process.argv0;
+function isDevMode(execPath) {
+    let executablePath = execPath ?? process.argv0;
     return /[\\/]electron.*$/.test(executablePath);
 }
 

--- a/app.js
+++ b/app.js
@@ -99,12 +99,6 @@ let openedAtLogin = (process.platform === 'darwin')
 
 if (!gotInstanceLock) {
     debugLog('Another instance is already running', 'warn');
-
-    electron.dialog.showErrorBox(
-        "Preventing launch",
-        "An instance of Google Assistant is already running.\nOperation Aborted"
-    )
-
     app.isQuiting = true;
     app.quit();
 }
@@ -115,6 +109,7 @@ else {
     app.commandLine.appendSwitch('enable-transparent-visuals');
     app.commandLine.appendSwitch('disable-features', 'HardwareMediaKeyHandling');
 
+    app.on('second-instance', launchAssistant);
     app.on('ready', () => setTimeout(onAppReady, 800));
 }
 


### PR DESCRIPTION
Instead of throwing an error, launch the Assistant.

This way we can trigger it from the desktop or taskbar, which can be more accessible than a keyboard shortcut or double-clicking the tray icon.
Fixes #94